### PR TITLE
change default settings for API QPS

### DIFF
--- a/kind.yaml
+++ b/kind.yaml
@@ -25,6 +25,8 @@ nodes:
     controllerManager:
       extraArgs:
         bind-address: 0.0.0.0
+        kube-api-qps: 1000
+        kube-api-burst: 1000
     etcd:
       local:
         extraArgs:
@@ -32,6 +34,8 @@ nodes:
     scheduler:
       extraArgs:
         bind-address: 0.0.0.0
+        kube-api-qps: 1000
+        kube-api-burst: 1000
     apiServer:
       extraArgs:
         audit-log-maxsize: '1024'

--- a/schedulers/volcano/volcano-controller/deployment.yaml
+++ b/schedulers/volcano/volcano-controller/deployment.yaml
@@ -21,8 +21,8 @@ spec:
         - --enable-healthz=true
         - --enable-metrics=true
         - --leader-elect=false
-        - --kube-api-qps=50
-        - --kube-api-burst=100
+        - --kube-api-qps=100
+        - --kube-api-burst=200
         - --worker-threads=3
         - --worker-threads-for-gc=5
         - --worker-threads-for-podgroup=5

--- a/schedulers/volcano/volcano-scheduler/deployment.yaml
+++ b/schedulers/volcano/volcano-scheduler/deployment.yaml
@@ -22,8 +22,8 @@ spec:
         - --enable-healthz=true
         - --enable-metrics=true
         - --leader-elect=false
-        - --kube-api-qps=2000
-        - --kube-api-burst=2000
+        - --kube-api-qps=1000
+        - --kube-api-burst=1000
         - --schedule-period=1s
         - --node-worker-threads=20
         - -v=3

--- a/test/kueue/main_test.go
+++ b/test/kueue/main_test.go
@@ -25,8 +25,8 @@ func TestMain(m *testing.M) {
 
 	restConfig := cfg.Client().RESTConfig()
 	restConfig.RateLimiter = nil
-	restConfig.QPS = 1000
-	restConfig.Burst = 1000
+	restConfig.QPS = 100
+	restConfig.Burst = 200
 
 	r, err = resources.New(restConfig)
 	if err != nil {

--- a/test/volcano/main_test.go
+++ b/test/volcano/main_test.go
@@ -25,8 +25,8 @@ func TestMain(m *testing.M) {
 
 	restConfig := cfg.Client().RESTConfig()
 	restConfig.RateLimiter = nil
-	restConfig.QPS = 1000
-	restConfig.Burst = 1000
+	restConfig.QPS = 100
+	restConfig.Burst = 200
 
 	r, err = resources.New(restConfig)
 	if err != nil {

--- a/test/yunikorn/main_test.go
+++ b/test/yunikorn/main_test.go
@@ -25,8 +25,8 @@ func TestMain(m *testing.M) {
 
 	restConfig := cfg.Client().RESTConfig()
 	restConfig.RateLimiter = nil
-	restConfig.QPS = 1000
-	restConfig.Burst = 1000
+	restConfig.QPS = 100
+	restConfig.Burst = 200
 
 	r, err = resources.New(restConfig)
 	if err != nil {


### PR DESCRIPTION
This PR changes the default settings for API QPS

- **scheduler:** API, qps and burst defaults to 1000. (YuniKorn defaults to 1000 by default, and can mutated via an [explicit ConfigMap](https://yunikorn.apache.org/docs/user_guide/service_config#default-configmap) - which i didn't include in this PR)
- **testing client:** qps defaults to 100, and burst defaults to 200 - as I envision the client will create Job-like workload, and hence the pod's reaction speed is on the controller side
- **controller-manager:** qps and burst defaults to 1000.