### PR TITLE
fix kubeadm config parameters

### DIFF
--- a/kind.yaml
+++ b/kind.yaml
@@ -21,21 +21,28 @@ nodes:
     kind: KubeProxyConfiguration
     metricsBindAddress: 0.0.0.0
   - |-
+    apiVersion: kubeadm.k8s.io/v1beta4
     kind: ClusterConfiguration
     controllerManager:
       extraArgs:
-        bind-address: 0.0.0.0
-        kube-api-qps: 1000
-        kube-api-burst: 1000
+      - name: bind-address
+        value: "0.0.0.0"
+      - name: kube-api-qps
+        value: "1000"
+      - name: kube-api-burst
+        value: "1000"
     etcd:
       local:
         extraArgs:
           listen-metrics-urls: http://0.0.0.0:2381
     scheduler:
       extraArgs:
-        bind-address: 0.0.0.0
-        kube-api-qps: 1000
-        kube-api-burst: 1000
+      - name: bind-address
+        value: "0.0.0.0"
+      - name: kube-api-qps
+        value: "1000"
+      - name: kube-api-burst
+        value: "1000"
     apiServer:
       extraArgs:
         audit-log-maxsize: '1024'


### PR DESCRIPTION
latest kubeadm config [v1beta4](https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta4/) introduced a breaking change:

> Replace the existing string/string extra argument maps with structured extra arguments that support duplicates. The change applies to ClusterConfiguration - apiServer.extraArgs, controllerManager.extraArgs, scheduler.extraArgs, etcd.local.extraArgs. Also to nodeRegistration.kubeletExtraArgs.

So `make up` with QPS parameters introduced in #1 failed to start:

```console
⇒  make up                                                                                       (⎈|N/A:N/A)
./hack/local-registry-with-load-images.sh
b4fb69c05d5225c825d51f9e3b1f8b3154c959c53ae1b08ba976a897cdb63e8a
./hack/kind-with-local-registry.sh
Creating cluster "kind" ...
 ✓ Ensuring node image (localhost:5001/docker.io/kindest/node:v1.32.2) 🖼
 ✓ Preparing nodes 📦
 ✓ Writing configuration 📜
 ✗ Starting control-plane 🕹️
Deleted nodes: ["kind-control-plane"]
ERROR: failed to create cluster: failed to init node with kubeadm: command "docker exec --privileged kind-control-plane kubeadm init --config=/kind/kubeadm.conf --skip-token-print --v=6" failed with error: exit status 1
Command Output: I0306 06:26:39.880676     234 initconfiguration.go:261] loading configuration from "/kind/kubeadm.conf"
W0306 06:26:39.880996     234 common.go:101] your configuration file uses a deprecated API spec: "kubeadm.k8s.io/v1beta3" (kind: "ClusterConfiguration"). Please use 'kubeadm config migrate --old-config old.yaml --new-config new.yaml', which will write the new, similar spec using a newer API version.
W0306 06:26:39.881249     234 initconfiguration.go:332] error unmarshaling configuration schema.GroupVersionKind{Group:"kubeadm.k8s.io", Version:"v1beta3", Kind:"ClusterConfiguration"}: json: cannot unmarshal number into Go struct field ControlPlaneComponent.controllerManager.extraArgs of type string
json: cannot unmarshal number into Go struct field ControlPlaneComponent.controllerManager.extraArgs of type string
make: *** [create-cluster] Error 1
```

This PR introduced the changes:

- use the latest format to define extraArgs
- add an explicit apiVersion for kubeadm `ClusterConfiguration`

I verified it works locally.