### PR TITLE
fix: resolve permission issues for non-root users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ output/
 results/
 bin/
 gopath/
+go-build/
 vendor/
 tmp/
 

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,9 @@ GO_IMAGE ?= $(IMAGE_PREFIX)docker.io/library/golang:1.24
 GOPROXY ?= https://proxy.golang.org,direct
 GOOS ?= $(shell uname -s | tr '[:upper:]' '[:lower:]')
 GO_IN_DOCKER = docker run --rm --network host \
+	-u $(shell id -u):$(shell id -g) \
 	-v $(shell pwd):/workspace/ -w /workspace/ \
-	-e GOOS=$(GOOS) -e CGO_ENABLED=0 -e GOPATH=/workspace/gopath/ -e GOPROXY=$(GOPROXY) $(GO_IMAGE)
+	-e GOOS=$(GOOS) -e CGO_ENABLED=0 -e GOPATH=/workspace/gopath/ -e GOPROXY=$(GOPROXY) -e GOCACHE=/workspace/.cache $(GO_IMAGE)
 
 TEST_ENVS = \
 		NODES_SIZE=$(NODES_SIZE) \
@@ -67,7 +68,7 @@ TEST_ENVS = \
 		GANG=$(GANG)
 
 .PHONY: default
-default:
+default: ensure-directories
 	make serial-test \
 		RESULT_RECENT_DURATION_SECONDS=250 TEST_TIMEOUT_SECONDS=350 \
 		NODES_SIZE=1000 \
@@ -101,6 +102,10 @@ default:
 		RESULT_RECENT_DURATION_SECONDS=300 TEST_TIMEOUT_SECONDS=400 \
 		NODES_SIZE=1000 GANG=true \
 		QUEUES_SIZE=1  JOBS_SIZE_PER_QUEUE=1      PODS_SIZE_PER_JOB=10000
+
+.PHONY: ensure-directories
+ensure-directories:
+	./hack/ensure-directories.sh
 
 define test-scheduler
 
@@ -185,7 +190,7 @@ down:
 		end-overview
 
 .PHONY: serial-test
-serial-test: bin/kind
+serial-test: ensure-directories bin/kind
 	$(foreach sched,$(SCHEDULERS), \
 		make prepare-$(sched); \
 		make start-$(sched); \

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ GOOS ?= $(shell uname -s | tr '[:upper:]' '[:lower:]')
 GO_IN_DOCKER = docker run --rm --network host \
 	-u $(shell id -u):$(shell id -g) \
 	-v $(shell pwd):/workspace/ -w /workspace/ \
-	-e GOOS=$(GOOS) -e CGO_ENABLED=0 -e GOPATH=/workspace/gopath/ -e GOPROXY=$(GOPROXY) -e GOCACHE=/workspace/.cache $(GO_IMAGE)
+	-e GOOS=$(GOOS) -e CGO_ENABLED=0 -e GOPATH=/workspace/gopath/ -e GOPROXY=$(GOPROXY) -e GOCACHE=/workspace/go-build $(GO_IMAGE)
 
 TEST_ENVS = \
 		NODES_SIZE=$(NODES_SIZE) \

--- a/hack/ensure-directories.sh
+++ b/hack/ensure-directories.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DIR="$(dirname "${BASH_SOURCE[0]}")"
+ROOT_DIR="$(realpath "${DIR}/..")"
+
+# Ensure all necessary directories exist with correct permissions
+echo "Creating directories with correct permissions..."
+
+# Function to ensure directory has correct ownership
+ensure_directory() {
+    local dir="$1"
+    local current_user=$(id -un)
+    local current_group=$(id -gn)
+    
+    # Create directory if it doesn't exist
+    mkdir -p "$dir"
+    
+    # Check ownership
+    local owner=$(stat -c '%U' "$dir" 2>/dev/null || echo "none")
+    
+    if [[ "$owner" == "root" ]]; then
+        echo "Fixing ownership of root-owned directory: $dir"
+        sudo chown -R "${current_user}:${current_group}" "$dir"
+    fi
+    
+    chmod 755 "$dir"
+    echo "Ensured directory: $dir (owner: $(stat -c '%U:%G' "$dir"))"
+}
+
+# Create logs directory
+ensure_directory "${ROOT_DIR}/logs"
+
+# Create bin directory
+ensure_directory "${ROOT_DIR}/bin"
+
+# Create gopath directory
+ensure_directory "${ROOT_DIR}/gopath"
+
+# Create registry-data directory
+ensure_directory "${ROOT_DIR}/registry-data"
+
+# Create output directory
+ensure_directory "${ROOT_DIR}/output"
+
+# Create results directory
+ensure_directory "${ROOT_DIR}/results"
+
+# Create tmp directory
+ensure_directory "${ROOT_DIR}/tmp"
+
+echo "Directories created successfully!" 

--- a/hack/ensure-directories.sh
+++ b/hack/ensure-directories.sh
@@ -20,7 +20,7 @@ ensure_directory() {
     mkdir -p "$dir"
     
     # Check ownership
-    local owner=$(stat -c '%U' "$dir" 2>/dev/null || echo "none")
+    local owner=$(ls -ld "$dir" 2>/dev/null | awk '{print $3}' || echo "none")
     
     if [[ "$owner" == "root" ]]; then
         echo "Fixing ownership of root-owned directory: $dir"
@@ -28,7 +28,7 @@ ensure_directory() {
     fi
     
     chmod 755 "$dir"
-    echo "Ensured directory: $dir (owner: $(stat -c '%U:%G' "$dir"))"
+    echo "Ensured directory: $dir (owner: $(ls -ld "$dir" | awk '{print $3":"$4}'))"
 }
 
 # Create logs directory
@@ -39,6 +39,9 @@ ensure_directory "${ROOT_DIR}/bin"
 
 # Create gopath directory
 ensure_directory "${ROOT_DIR}/gopath"
+
+# Create go-build directory
+ensure_directory "${ROOT_DIR}/go-build"
 
 # Create registry-data directory
 ensure_directory "${ROOT_DIR}/registry-data"


### PR DESCRIPTION
# 问题描述 / Problem Description

当非 root 用户执行 `make` 命令时出现权限错误：

```bash
mv: 无法将"./logs" 移动至"./tmp/logs": 权限不够
failed to initialize build cache at /.cache/go-build: mkdir /.cache: permission denied
```

**根本原因**：
- Docker 容器内进程默认以 root 用户运行，创建的文件/目录归属 root
- Go 构建缓存路径权限问题，导致非 root 用户无法写入

# 解决方案 / Solution

## 1. Docker 用户权限映射
- 在 `Makefile` 中添加 `-u $(shell id -u):$(shell id -g)` 参数
- 让容器以当前用户身份运行，避免创建 root 拥有的文件

## 2. Go 构建缓存路径
- 设置 `GOCACHE=/workspace/.cache` 环境变量
- 确保 Go 构建缓存在有权限的工作目录下创建

## 3. 目录权限修复脚本
- 创建 `hack/ensure-directories.sh` 脚本
- 自动创建必要目录并修复权限问题
- 集成到 Makefile 构建流程中

# 变更内容 / Changes

- **Makefile**: 添加用户 ID 映射和 GOCACHE 环境变量设置
- **hack/ensure-directories.sh**: 新增权限修复脚本，确保目录正确ownership
- **构建流程**: 在 `default` 和 `serial-test` 目标中集成权限检查